### PR TITLE
[FEATURE] 도봉구 장소 정보와 리뷰 반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // MySQL
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.mysql:mysql-connector-j'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/dobongzip/dobong/domain/map/client/GooglePlacesClientV1.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/client/GooglePlacesClientV1.java
@@ -1,0 +1,188 @@
+package com.dobongzip.dobong.domain.map.client;
+
+import com.dobongzip.dobong.domain.map.dto.response.PlacesV1PlaceDetailsResponse;
+import com.dobongzip.dobong.domain.map.dto.response.PlacesV1SearchTextResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GooglePlacesClientV1 {
+
+    private static final String BASE = "https://places.googleapis.com/v1";
+
+    private final RestTemplate restTemplate;
+    private final GooglePlacesProperties props;
+
+    /** 검색용 필드마스크 (카드 목록) */
+    private static final String SEARCH_FIELD_MASK = String.join(",",
+            "places.id",
+            "places.displayName",
+            "places.formattedAddress",
+            "places.googleMapsUri",
+            "places.location",
+            "places.priceLevel",
+            "places.photos",
+            "places.currentOpeningHours.weekdayDescriptions",
+            "places.rating",
+            "places.userRatingCount",
+            // 소개 관련
+            "places.editorialSummary",
+            "places.generativeSummary.overview",
+            "places.generativeSummary.description",
+            // 보조 맥락
+            "places.areaSummary",
+            "places.addressDescriptor"
+    );
+
+    /** 상세용 필드마스크 (상세 화면) */
+    private static final String DETAIL_FIELD_MASK = String.join(",",
+            "id",
+            "displayName",
+            "formattedAddress",
+            "internationalPhoneNumber",
+            "nationalPhoneNumber",
+            "currentOpeningHours.weekdayDescriptions",
+            "priceLevel",
+            "rating",
+            "userRatingCount",
+            "photos",
+            // 소개(최우선)
+            "editorialSummary",
+            "generativeSummary.overview",
+            "generativeSummary.description",
+            // 보조 맥락
+            "areaSummary",
+            "addressDescriptor",
+            // 위키 geosearch용 좌표
+            "location"
+    );
+
+    /** 리뷰용 필드마스크(최소) */
+    private static final String REVIEWS_FIELD_MASK = String.join(",",
+            "id",
+            "rating",
+            "userRatingCount",
+            "reviews"
+    );
+
+    // ==========================
+    // 검색(목록)
+    // ==========================
+    public PlacesV1SearchTextResponse searchDobongAttractions() {
+        URI uri = URI.create(BASE + "/places:searchText");
+        HttpHeaders headers = newHeaders(SEARCH_FIELD_MASK);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = Map.of(
+                "textQuery", "도봉구 명소",
+                "languageCode", props.getLanguage(),
+                "regionCode",  props.getRegion()
+        );
+
+        ResponseEntity<PlacesV1SearchTextResponse> res =
+                postJson(uri, headers, body, PlacesV1SearchTextResponse.class);
+
+        log.info("[PLACES v1 search] http={} size={}",
+                res.getStatusCodeValue(),
+                res.getBody() != null && res.getBody().getPlaces() != null
+                        ? res.getBody().getPlaces().size() : 0);
+
+        return res.getBody();
+    }
+
+    // ==========================
+    // 상세
+    // ==========================
+    public PlacesV1PlaceDetailsResponse fetchPlaceDetails(String placeId) {
+        String id = normalizePlaceId(placeId);
+        URI uri = UriComponentsBuilder.fromHttpUrl(BASE + "/places/" + id)
+                .queryParam("languageCode", props.getLanguage())
+                .queryParam("regionCode", props.getRegion())
+                .build(true)
+                .toUri();
+
+        HttpHeaders headers = newHeaders(DETAIL_FIELD_MASK);
+
+        ResponseEntity<PlacesV1PlaceDetailsResponse> res =
+                exchangeGet(uri, headers, PlacesV1PlaceDetailsResponse.class);
+
+        return res.getBody();
+    }
+
+    // ==========================
+    // 리뷰 전용
+    // ==========================
+    public PlacesV1PlaceDetailsResponse fetchPlaceReviews(String placeId) {
+        String id = normalizePlaceId(placeId);
+        URI uri = UriComponentsBuilder.fromHttpUrl(BASE + "/places/" + id)
+                .queryParam("languageCode", props.getLanguage())
+                .queryParam("regionCode", props.getRegion())
+                .build(true)
+                .toUri();
+
+        HttpHeaders headers = newHeaders(REVIEWS_FIELD_MASK);
+
+        ResponseEntity<PlacesV1PlaceDetailsResponse> res =
+                exchangeGet(uri, headers, PlacesV1PlaceDetailsResponse.class);
+
+        return res.getBody();
+    }
+
+    // ==========================
+    // 유틸
+    // ==========================
+    private HttpHeaders newHeaders(String fieldMask) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.set("X-Goog-Api-Key", props.getApiKey());
+        headers.set("X-Goog-FieldMask", fieldMask);
+        headers.set("Accept-Language", props.getLanguage());
+        return headers;
+    }
+
+    private <T> ResponseEntity<T> exchangeGet(URI uri, HttpHeaders headers, Class<T> type) {
+        try {
+            return restTemplate.exchange(uri, HttpMethod.GET, new HttpEntity<>(headers), type);
+        } catch (HttpStatusCodeException e) {
+            log.error("[PLACES v1 GET] uri={} status={} body={}",
+                    uri, e.getStatusCode().value(), e.getResponseBodyAsString());
+            throw e;
+        }
+    }
+
+    private <T> ResponseEntity<T> postJson(URI uri, HttpHeaders headers, Object body, Class<T> type) {
+        try {
+            return restTemplate.exchange(uri, HttpMethod.POST, new HttpEntity<>(body, headers), type);
+        } catch (HttpStatusCodeException e) {
+            log.error("[PLACES v1 POST] {} -> status={} body={}",
+                    uri, e.getStatusCode().value(), e.getResponseBodyAsString());
+            throw e;
+        }
+    }
+
+    public String buildPhotoUrl(String photoName, int maxWidthPx) {
+        if (photoName == null) return null;
+        int w = Math.max(100, Math.min(maxWidthPx, 1600));
+        return BASE + "/" + photoName + "/media?maxWidthPx=" + w + "&key=" + props.getApiKey();
+    }
+
+    public String buildMapsUrl(String googleMapsUri) {
+        return googleMapsUri;
+    }
+
+    private String normalizePlaceId(String placeId) {
+        if (placeId == null) return "";
+        return placeId.startsWith("places/") ? placeId.substring("places/".length()) : placeId;
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/client/GooglePlacesConfig.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/client/GooglePlacesConfig.java
@@ -1,0 +1,17 @@
+package com.dobongzip.dobong.domain.map.client;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class GooglePlacesConfig {
+    @Bean
+    public RestTemplate restTemplate(org.springframework.boot.web.client.RestTemplateBuilder builder) {
+        return builder
+                .defaultHeader(org.springframework.http.HttpHeaders.USER_AGENT,
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                                + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36")
+                .build();
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/client/GooglePlacesProperties.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/client/GooglePlacesProperties.java
@@ -1,0 +1,20 @@
+package com.dobongzip.dobong.domain.map.client;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "google.places")
+public class GooglePlacesProperties {
+    private String apiKey;
+    private String language;
+    private String region;
+    private int radiusM;
+
+    public void setApiKey(String apiKey) { this.apiKey = apiKey; }
+    public void setLanguage(String language) { this.language = language; }
+    public void setRegion(String region) { this.region = region; }
+    public void setRadiusM(int radiusM) { this.radiusM = radiusM; }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/client/WikipediaClient.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/client/WikipediaClient.java
@@ -1,0 +1,167 @@
+package com.dobongzip.dobong.domain.map.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WikipediaClient {
+
+    private final RestTemplate restTemplate;
+
+    // 반경을 넉넉하게 (m)
+    private static final int GEOSEARCH_RADIUS_M = 3000;
+
+    /**
+     * 이름으로 요약 시도 → 이름 검색(search) → 좌표 기반 geosearch 순서.
+     * ko 우선, 실패 시 en 시도.
+     */
+    public Optional<String> getSummary(String nameKo, Double lat, Double lng) {
+        try {
+            // 1) 제목 직행
+            if (nonEmpty(nameKo)) {
+                // ko
+                String s = fetchSummary("ko", nameKo);
+                if (nonEmpty(s)) return Optional.of(s);
+                // en
+                s = fetchSummary("en", nameKo);
+                if (nonEmpty(s)) return Optional.of(s);
+            }
+
+            // 2) 제목 검색 (search)
+            if (nonEmpty(nameKo)) {
+                // ko
+                String t = searchTitle("ko", nameKo);
+                if (nonEmpty(t)) {
+                    String s = fetchSummary("ko", t);
+                    if (nonEmpty(s)) return Optional.of(s);
+                }
+                // en
+                t = searchTitle("en", nameKo);
+                if (nonEmpty(t)) {
+                    String s = fetchSummary("en", t);
+                    if (nonEmpty(s)) return Optional.of(s);
+                }
+            }
+
+            // 3) 좌표 기반 geosearch
+            if (lat != null && lng != null) {
+                // ko
+                String t = geosearchTitle("ko", lat, lng);
+                if (nonEmpty(t)) {
+                    String s = fetchSummary("ko", t);
+                    if (nonEmpty(s)) return Optional.of(s);
+                }
+                // en
+                t = geosearchTitle("en", lat, lng);
+                if (nonEmpty(t)) {
+                    String s = fetchSummary("en", t);
+                    if (nonEmpty(s)) return Optional.of(s);
+                }
+            }
+
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("[Wikipedia] failed: {}", e.toString());
+            return Optional.empty();
+        }
+    }
+
+    /** Wikimedia REST summary */
+    private String fetchSummary(String lang, String title) {
+        try {
+            String enc = URLEncoder.encode(title.trim(), StandardCharsets.UTF_8);
+            URI u = UriComponentsBuilder
+                    .fromHttpUrl("https://" + lang + ".wikipedia.org/api/rest_v1/page/summary/" + enc)
+                    .build(true).toUri();
+
+            HttpHeaders h = new HttpHeaders();
+            h.set("User-Agent", "DobongZip/1.0 (contact: dev@example.com)");
+            ResponseEntity<Map> res = restTemplate.exchange(u, HttpMethod.GET, new HttpEntity<>(h), Map.class);
+            Object extract = res.getBody() != null ? res.getBody().get("extract") : null;
+            return (extract instanceof String s) ? s.trim() : null;
+        } catch (HttpStatusCodeException e) {
+            return null; // 404 등 무시
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** MediaWiki search API (제목 검색) */
+    private String searchTitle(String lang, String query) {
+        try {
+            URI u = UriComponentsBuilder
+                    .fromHttpUrl("https://" + lang + ".wikipedia.org/w/api.php")
+                    .queryParam("action", "query")
+                    .queryParam("list", "search")
+                    .queryParam("srsearch", query)
+                    .queryParam("srlimit", 1)
+                    .queryParam("format", "json")
+                    .build(true).toUri();
+
+            HttpHeaders h = new HttpHeaders();
+            h.set("User-Agent", "DobongZip/1.0 (contact: dev@example.com)");
+            ResponseEntity<Map> res = restTemplate.exchange(u, HttpMethod.GET, new HttpEntity<>(h), Map.class);
+
+            Map body = res.getBody();
+            if (body == null) return null;
+            Map q = (Map) body.get("query");
+            if (q == null) return null;
+            List s = (List) q.get("search");
+            if (s == null || s.isEmpty()) return null;
+
+            Map first = (Map) s.get(0);
+            Object title = first.get("title");
+            return title != null ? String.valueOf(title) : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** MediaWiki geosearch (좌표 주변에서 가장 가까운 문서 제목) */
+    private String geosearchTitle(String lang, double lat, double lng) {
+        try {
+            URI u = UriComponentsBuilder
+                    .fromHttpUrl("https://" + lang + ".wikipedia.org/w/api.php")
+                    .queryParam("action", "query")
+                    .queryParam("list", "geosearch")
+                    .queryParam("gscoord", lat + "|" + lng)
+                    .queryParam("gsradius", GEOSEARCH_RADIUS_M)
+                    .queryParam("gslimit", 1)
+                    .queryParam("format", "json")
+                    .build(true).toUri();
+
+            HttpHeaders h = new HttpHeaders();
+            h.set("User-Agent", "DobongZip/1.0 (contact: dev@example.com)");
+            ResponseEntity<Map> res = restTemplate.exchange(u, HttpMethod.GET, new HttpEntity<>(h), Map.class);
+
+            Map body = res.getBody();
+            if (body == null) return null;
+            Map query = (Map) body.get("query");
+            if (query == null) return null;
+            List gs = (List) query.get("geosearch");
+            if (gs == null || gs.isEmpty()) return null;
+
+            Map first = (Map) gs.get(0);
+            Object title = first.get("title");
+            return title != null ? String.valueOf(title) : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static boolean nonEmpty(String s) { return s != null && !s.isBlank(); }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/controller/PlaceController.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/controller/PlaceController.java
@@ -1,0 +1,56 @@
+package com.dobongzip.dobong.domain.map.controller;
+
+import com.dobongzip.dobong.domain.map.dto.response.PlaceDetailsResponse;
+import com.dobongzip.dobong.domain.map.dto.response.PlaceDto;
+import com.dobongzip.dobong.domain.map.dto.response.ReviewListResponse;
+import com.dobongzip.dobong.domain.map.service.PlaceService;
+import com.dobongzip.dobong.global.response.CommonResponse;
+import jakarta.validation.constraints.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/v1/places", produces = MediaType.APPLICATION_JSON_VALUE)
+@Validated
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    /** ① 검색(목록/카드) — 이름, 별점, 리뷰수, 거리, 전화(있으면), 대표사진 1장 */
+    // 예: GET /api/v1/places/dobong?lat=37.665&lng=127.043&limit=10
+    @GetMapping("/dobong")
+    public ResponseEntity<CommonResponse<List<PlaceDto>>> getDobong(
+            @RequestParam @DecimalMin("-90.0")  @DecimalMax("90.0")  double lat,
+            @RequestParam @DecimalMin("-180.0") @DecimalMax("180.0") double lng,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(30) int limit
+    ) {
+        int capped = Math.max(1, Math.min(limit, 30));
+        var list = placeService.findDobongAttractions(lat, lng, capped);
+        return ResponseEntity.ok(CommonResponse.onSuccess(list));
+    }
+
+    /** ② 상세 — 장소 소개(에디토리얼/제너러티브), 주소, 이용시간, 이용금액(가격레벨), 사진들, 전화, 별점/리뷰수 */
+    // 예: GET /api/v1/places/{placeId}
+    @GetMapping("/{placeId}")
+    public ResponseEntity<CommonResponse<PlaceDetailsResponse>> getPlaceDetail(@PathVariable String placeId) {
+        var dto = placeService.getPlaceDetail(placeId);
+        return ResponseEntity.ok(CommonResponse.onSuccess(dto));
+    }
+
+    /** ③ 리뷰 목록 — 평균 별점, 리뷰수, 리뷰 리스트(작성자/별점/본문/상대시간/아바타 등) */
+    // 예: GET /api/v1/places/{placeId}/reviews?limit=20
+    @GetMapping("/{placeId}/reviews")
+    public ResponseEntity<CommonResponse<ReviewListResponse>> getPlaceReviews(
+            @PathVariable String placeId,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
+    ) {
+        var dto = placeService.getPlaceReviews(placeId, limit);
+        return ResponseEntity.ok(CommonResponse.onSuccess(dto));
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlaceDetailsResponse.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlaceDetailsResponse.java
@@ -1,0 +1,28 @@
+package com.dobongzip.dobong.domain.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class PlaceDetailsResponse {
+    private String placeId;
+    private String name;
+    private String address;
+    private String description;        // editorial → generative 순 폴백
+    private List<String> openingHours; // 요일별 이용시간
+    private Integer priceLevel;        // 이용금액 레벨(0~4)
+    private String phone;              // 국제/국내
+    private Double rating;             // 평균 별점
+    private Integer reviewCount;       // 리뷰 수
+    private List<String> photos;       // 여러 장
+    private Location location;
+    private boolean liked;
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Location {
+        private double latitude;
+        private double longitude;
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlaceDto.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlaceDto.java
@@ -1,0 +1,30 @@
+package com.dobongzip.dobong.domain.map.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder(toBuilder = true)
+public class PlaceDto {
+    private String placeId;
+    private String name;
+    private String address;
+    private double latitude;
+    private double longitude;
+
+    private long distanceMeters;
+    private String distanceText;
+
+    private String imageUrl;
+    private String description;       // (요약 있을 때)
+    private List<String> openingHours;
+    private Integer priceLevel;
+    private String mapsUrl;
+    private String phone;
+
+    // 👇 추가
+    private Double rating;            // 평균 별점
+    private Integer reviewCount;      // 리뷰 수
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlacesV1PlaceDetailsResponse.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlacesV1PlaceDetailsResponse.java
@@ -1,0 +1,95 @@
+package com.dobongzip.dobong.domain.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlacesV1PlaceDetailsResponse {
+    private String id;
+    private DisplayName displayName;
+    private String internationalPhoneNumber;
+    private String nationalPhoneNumber;
+    private EditorialSummary editorialSummary;
+    private GenerativeSummary generativeSummary;
+
+    private String formattedAddress;
+    private OpeningHours currentOpeningHours;
+    private Integer priceLevel;
+    private Double rating;
+    private Integer userRatingCount;
+    private List<Photo> photos;
+
+    // 보조 요약 필드들
+    private LocalizedText areaSummary;
+    private AddressDescriptor addressDescriptor;
+
+    // 위키 geosearch용 좌표
+    private Location location;
+
+    // reviews
+    private List<Review> reviews;
+
+    @Getter public static class DisplayName { private String text; }
+
+    @Getter public static class EditorialSummary { private String overview; }
+
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class GenerativeSummary {
+        private LocalizedText overview;
+        private LocalizedText description;
+    }
+
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OpeningHours { private List<String> weekdayDescriptions; }
+
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Photo { private String name; }
+
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LocalizedText {
+        private String text;
+        private String languageCode;
+    }
+
+    // AddressDescriptor 구조
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AddressDescriptor {
+        private List<Landmark> landmarks;
+        private List<Area> areas;
+    }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Landmark {
+        private String placeId;
+        private LocalizedText displayName;
+    }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Area {
+        private String placeId;
+        private LocalizedText displayName;
+    }
+
+    // 위치
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Location {
+        private double latitude;
+        private double longitude;
+    }
+
+    // 리뷰
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Review {
+        private AuthorAttribution authorAttribution;
+        private Double rating;
+        private LocalizedText text;
+        private String relativePublishTimeDescription;
+
+        @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class AuthorAttribution {
+            private String displayName;
+            private String uri;
+            private String photoUri;
+        }
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlacesV1SearchTextResponse.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/PlacesV1SearchTextResponse.java
@@ -1,0 +1,56 @@
+package com.dobongzip.dobong.domain.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlacesV1SearchTextResponse {
+    private List<Place> places;
+
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Place {
+        private String id;
+        private DisplayName displayName;
+        private String formattedAddress;
+        private String googleMapsUri;
+        private Location location;
+        private OpeningHours currentOpeningHours;
+        private EditorialSummary editorialSummary;
+        private GenerativeSummary generativeSummary;
+
+        private LocalizedText areaSummary;
+        private AddressDescriptor addressDescriptor;
+
+        private Integer priceLevel;
+        private List<Photo> photos;
+        private Double rating;
+        private Integer userRatingCount;
+    }
+
+    // AddressDescriptor 구조 (검색 응답용)
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AddressDescriptor {
+        private List<Landmark> landmarks;
+        private List<Area> areas;
+    }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Landmark {
+        private String placeId;
+        private LocalizedText displayName;
+    }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Area {
+        private String placeId;
+        private LocalizedText displayName;
+    }
+
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class DisplayName { private String text; }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class Location { private double latitude; private double longitude; }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class OpeningHours { private List<String> weekdayDescriptions; }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class EditorialSummary { private String overview; }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class Photo { private String name; }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class GenerativeSummary { private LocalizedText overview; private LocalizedText description; }
+    @Getter @JsonIgnoreProperties(ignoreUnknown = true) public static class LocalizedText { private String text; private String languageCode; }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/ReviewListResponse.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/ReviewListResponse.java
@@ -1,0 +1,24 @@
+package com.dobongzip.dobong.domain.map.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class ReviewListResponse {
+    private String placeId;
+    private Double rating;          // 평균 별점
+    private Integer reviewCount;    // 전체 리뷰 수
+    private List<Review> reviews;   // 상위 N개
+
+    @Getter
+    @Builder
+    public static class Review {
+        private String authorName;         // 작성자 이름(있을 때)
+        private String authorProfilePhoto; // 아바타 URL(있을 때)
+        private Double rating;             // 별점
+        private String text;               // 본문
+        private String relativeTime;       // "1시간 전" 등
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/service/PlaceService.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/service/PlaceService.java
@@ -1,0 +1,236 @@
+package com.dobongzip.dobong.domain.map.service;
+
+import com.dobongzip.dobong.domain.map.client.GooglePlacesClientV1;
+import com.dobongzip.dobong.domain.map.client.WikipediaClient;
+import com.dobongzip.dobong.domain.map.dto.response.PlaceDetailsResponse;
+import com.dobongzip.dobong.domain.map.dto.response.PlaceDto;
+import com.dobongzip.dobong.domain.map.dto.response.PlacesV1PlaceDetailsResponse;
+import com.dobongzip.dobong.domain.map.dto.response.PlacesV1SearchTextResponse;
+import com.dobongzip.dobong.domain.map.dto.response.ReviewListResponse;
+import com.dobongzip.dobong.domain.map.util.GeoUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+    private final GooglePlacesClientV1 v1;
+    private final WikipediaClient wikipedia;
+
+    public List<PlaceDto> findDobongAttractions(double userLat, double userLng, int limit) {
+        PlacesV1SearchTextResponse res = v1.searchDobongAttractions();
+        if (res == null || res.getPlaces() == null || res.getPlaces().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 1차: Text Search 결과로 기본 정보 구성
+        var top = res.getPlaces().stream()
+                .limit(Math.max(1, Math.min(limit * 2L, 30)))
+                .toList();
+
+        List<PlaceDto> rough = new ArrayList<>(top.size());
+        for (var p : top) {
+            if (p.getLocation() == null) continue;
+            double lat = p.getLocation().getLatitude();
+            double lng = p.getLocation().getLongitude();
+            long dist = GeoUtils.haversineMeters(userLat, userLng, lat, lng);
+
+            String photoName = (p.getPhotos() != null && !p.getPhotos().isEmpty())
+                    ? p.getPhotos().get(0).getName() : null;
+
+            // 카드용 소개(구글 데이터만 사용)
+            String summary = pickSummaryFromSearch(p);
+
+            rough.add(PlaceDto.builder()
+                    .placeId(p.getId())
+                    .name(p.getDisplayName() != null ? p.getDisplayName().getText() : null)
+                    .address(p.getFormattedAddress())
+                    .latitude(lat)
+                    .longitude(lng)
+                    .distanceMeters(dist)
+                    .distanceText(GeoUtils.formatDistance(dist))
+                    .imageUrl(v1.buildPhotoUrl(photoName, 800))
+                    .description(summary)
+                    .openingHours(p.getCurrentOpeningHours() != null ? p.getCurrentOpeningHours().getWeekdayDescriptions() : null)
+                    .priceLevel(p.getPriceLevel())
+                    .mapsUrl(v1.buildMapsUrl(p.getGoogleMapsUri()))
+                    .rating(p.getRating())
+                    .reviewCount(p.getUserRatingCount())
+                    .build());
+        }
+
+        // 2차: 정렬 → 최종 상위 limit만 상세조회
+        var primaries = rough.stream()
+                .sorted(Comparator.comparingLong(PlaceDto::getDistanceMeters))
+                .limit(Math.max(1, limit))
+                .toList();
+
+        List<PlaceDto> enriched = new ArrayList<>(primaries.size());
+        for (PlaceDto base : primaries) {
+            var details = v1.fetchPlaceDetails(base.getPlaceId());
+
+            String phone = null;
+            String desc  = base.getDescription(); // 카드에서 이미 있으면 유지(목록은 위키 미사용)
+
+            if (details != null) {
+                // phone: 국제 → 국내 우선
+                phone = firstNonNull(details.getInternationalPhoneNumber(), details.getNationalPhoneNumber());
+
+                // 상세 설명은 화면에서 위키를 쓰므로, 목록 단계에서는 구글 폴백만 유지
+                if (desc == null) {
+                    desc =  pickSummaryFromDetailsStrict(details);
+                }
+            }
+            if (desc == null) desc = "자세한 설명이 없습니다.";
+
+            enriched.add(base.toBuilder().phone(phone).description(desc).build());
+        }
+
+        return enriched;
+    }
+
+    public PlaceDetailsResponse getPlaceDetail(String placeId) {
+        var d = v1.fetchPlaceDetails(placeId);
+        if (d == null) return null;
+
+        String name = d.getDisplayName() != null ? d.getDisplayName().getText() : null;
+        Double lat = (d.getLocation() != null) ? d.getLocation().getLatitude() : null;
+        Double lng = (d.getLocation() != null) ? d.getLocation().getLongitude() : null;
+
+        // 1) Wikipedia 우선
+        String desc = wikipedia.getSummary(name, lat, lng).orElse(null);
+
+        // 2) 위키 실패 → Google 소개 중 "문단형"만 사용 (addressDescriptor는 제외!)
+        if (!nonEmpty(desc)) {
+            desc = pickSummaryFromDetailsStrict(d); //  addressDescriptor 안 씀
+        }
+
+        if (!nonEmpty(desc)) desc = "자세한 설명이 없습니다.";
+
+        String phone = firstNonNull(d.getInternationalPhoneNumber(), d.getNationalPhoneNumber());
+
+        List<String> photoUrls = Optional.ofNullable(d.getPhotos())
+                .orElseGet(List::of).stream()
+                .limit(8)
+                .map(p -> v1.buildPhotoUrl(p.getName(), 1280))
+                .toList();
+
+        return PlaceDetailsResponse.builder()
+                .placeId(d.getId())
+                .name(name)
+                .address(d.getFormattedAddress())
+                .description(desc)
+                .openingHours(d.getCurrentOpeningHours() != null ? d.getCurrentOpeningHours().getWeekdayDescriptions() : null)
+                .priceLevel(d.getPriceLevel())
+                .phone(phone)
+                .rating(d.getRating())
+                .reviewCount(d.getUserRatingCount())
+                .photos(photoUrls)
+                .build();
+    }
+
+
+    public ReviewListResponse getPlaceReviews(String placeId, int limit) {
+        var d = v1.fetchPlaceReviews(placeId);
+        if (d == null) return ReviewListResponse.builder()
+                .placeId(placeId).rating(null).reviewCount(0).reviews(List.of()).build();
+
+        var reviews = Optional.ofNullable(d.getReviews())
+                .orElseGet(List::of).stream()
+                .limit(limit)
+                .map(r -> ReviewListResponse.Review.builder()
+                        .authorName(r.getAuthorAttribution() != null ? r.getAuthorAttribution().getDisplayName() : null)
+                        .authorProfilePhoto(r.getAuthorAttribution() != null ? r.getAuthorAttribution().getPhotoUri() : null)
+                        .rating(r.getRating())
+                        .text(r.getText() != null ? r.getText().getText() : null)
+                        .relativeTime(r.getRelativePublishTimeDescription())
+                        .build())
+                .toList();
+
+        return ReviewListResponse.builder()
+                .placeId(d.getId())
+                .rating(d.getRating())
+                .reviewCount(d.getUserRatingCount())
+                .reviews(reviews)
+                .build();
+    }
+
+    // ==========================
+    // 내부 헬퍼
+    // ==========================
+    private static String pickSummaryFromSearch(PlacesV1SearchTextResponse.Place p) {
+        if (p.getEditorialSummary() != null && nonEmpty(p.getEditorialSummary().getOverview())) {
+            return p.getEditorialSummary().getOverview();
+        }
+        if (p.getGenerativeSummary() != null) {
+            var gs = p.getGenerativeSummary();
+            if (gs.getDescription() != null && nonEmpty(gs.getDescription().getText())) {
+                return gs.getDescription().getText();
+            }
+            if (gs.getOverview() != null && nonEmpty(gs.getOverview().getText())) {
+                return gs.getOverview().getText();
+            }
+        }
+        if (p.getAreaSummary() != null && nonEmpty(p.getAreaSummary().getText())) {
+            return p.getAreaSummary().getText();
+        }
+        // 카드에서는 허용
+        if (p.getAddressDescriptor() != null) {
+            String ad = summarizeAddressDescriptor(
+                    p.getAddressDescriptor().getLandmarks(),
+                    p.getAddressDescriptor().getAreas(),
+                    false
+            );
+            if (nonEmpty(ad)) return ad;
+        }
+        return null;
+    }
+
+    // 상세: 문단형 텍스트만 허용 — addressDescriptor는 제외
+    private static String pickSummaryFromDetailsStrict(PlacesV1PlaceDetailsResponse d) {
+        if (d.getEditorialSummary() != null && nonEmpty(d.getEditorialSummary().getOverview())) {
+            return d.getEditorialSummary().getOverview();
+        }
+        if (d.getGenerativeSummary() != null) {
+            var gs = d.getGenerativeSummary();
+            if (gs.getDescription() != null && nonEmpty(gs.getDescription().getText())) {
+                return gs.getDescription().getText();
+            }
+            if (gs.getOverview() != null && nonEmpty(gs.getOverview().getText())) {
+                return gs.getOverview().getText();
+            }
+        }
+        if (d.getAreaSummary() != null && nonEmpty(d.getAreaSummary().getText())) {
+            return d.getAreaSummary().getText();
+        }
+        // addressDescriptor(“~ 인근/일대”)는 상세에서 사용 금지
+        return null;
+    }
+
+    private static String summarizeAddressDescriptor(List<?> landmarks, List<?> areas, boolean isDetail) {
+        String lmName = extractDisplayNameText(landmarks);
+        if (nonEmpty(lmName)) return lmName + " 인근";
+        String areaName = extractDisplayNameText(areas);
+        if (nonEmpty(areaName)) return areaName + " 일대";
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String extractDisplayNameText(List<?> items) {
+        if (items == null || items.isEmpty()) return null;
+        Object first = items.get(0);
+        try {
+            var disp = first.getClass().getMethod("getDisplayName").invoke(first);
+            if (disp == null) return null;
+            var text = disp.getClass().getMethod("getText").invoke(disp);
+            return text != null ? text.toString() : null;
+        } catch (ReflectiveOperationException ignored) {
+            return null;
+        }
+    }
+
+    private static boolean nonEmpty(String s) { return s != null && !s.isBlank(); }
+    private static <T> T firstNonNull(T a, T b) { return (a != null) ? a : b; }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/util/GeoUtils.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/util/GeoUtils.java
@@ -1,0 +1,21 @@
+package com.dobongzip.dobong.domain.map.util;
+
+public class GeoUtils {
+    private static final double EARTH_RADIUS_M = 6371000.0;
+
+    public static long haversineMeters(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat/2)*Math.sin(dLat/2)
+                + Math.cos(Math.toRadians(lat1))*Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon/2)*Math.sin(dLon/2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        return Math.round(EARTH_RADIUS_M * c);
+    }
+
+    public static String formatDistance(long meters) {
+        double km = meters / 1000.0;
+        return String.format("%.1f km", km);
+    }
+
+}

--- a/src/main/java/com/dobongzip/dobong/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dobongzip/dobong/global/security/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/auth/**",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**","/api/mainpage/**","/api/map/**"
+                                "/v3/api-docs/**","/api/v1/mainpage/**","/api/v1/places/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,12 +3,55 @@ spring:
     activate:
       on-profile: "dev"
 
+  datasource:
+    url: ${DEV_DB_URL}
+    username: ${DEV_DB_USER}
+    password: ${DEV_DB_PASSWORD}
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        use_sql_comments: true
+  jwt:
+    access:
+      expiration: ${JWT_EXPIRATION}
+    secret: ${JWT_SECRET_KEY}
+
+  seoul:
+    openapi:
+      key: ${DOBONG_EVENT}
+    api:
+      base-url: ${URL_DOBONG_EVENT}
+
+  dobong:
+    api:
+      base-url: ${DOBONG_HERI}
+      api-key: ${API_KEY}
+      cont-code: ${CONT_CODE}
+
+
+  kakao:
+    rest-key: ${KAKAO_REST_KEY}
+
+
+
+
+kakao:
+  rest-api-key: ${KAKAO_AUTH_API_KEY}       # 카카오 REST API Key (aud 검증용)
+  oidc:
+    issuer: https://kauth.kakao.com
+    jwks-uri: https://kauth.kakao.com/.well-known/jwks.json
+
+google:
+  client-id: ${GOOGLE_WEB_CLIENT_ID}
+  oidc:
+    issuer: https://accounts.google.com
+    jwks-uri: https://www.googleapis.com/oauth2/v3/certs
+
+  places:
+    api-key: ${GOOGLE_PLACES_API_KEY}   # 환경변수로 주입 권장
+    language: ko
+    region: KR
+
+
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: DEBUG

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,6 @@ spring:
       on-profile: "local"
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${LOCAL_DB_URL}
     username: ${LOCAL_DB_USER}
     password: ${LOCAL_DB_PASSWORD}
@@ -40,11 +39,15 @@ kakao:
     jwks-uri: https://kauth.kakao.com/.well-known/jwks.json
 
 google:
-
   client-id: ${GOOGLE_WEB_CLIENT_ID}
   oidc:
     issuer: https://accounts.google.com
     jwks-uri: https://www.googleapis.com/oauth2/v3/certs
+
+  places:
+    api-key: ${GOOGLE_PLACES_API_KEY}   # 환경변수로 주입 권장
+    language: ko
+    region: KR
 
 server:
   port: 8080


### PR DESCRIPTION
## 📌 PR 개요

Google Places API(v1) 연동으로 도봉구 명소 검색/상세/리뷰 데이터를 제공하고, 상세 페이지의 장소 소개는 Wikipedia 요약(가능 시) → Google editorialSummary/generativeSummary 등의 폴백 체인으로 채웁니다.

## ✅ 작업한 사항 (체크리스트)

- [ ] 기능 구현 완료
- [ ] 기존 코드와 충돌 없음
- [ ] 문서 업데이트 필요 (필요 시)

## 🚧 변경 사항 상세 설명

1) API 엔드포인트

GET /api/v1/places/dobong?lat={..}&lng={..}&limit={..}

- 목록 카드: 이름/주소/좌표/거리/대표사진/가격레벨/영업시간/별점/리뷰수/설명(구글 데이터 기반 간단 요약)

GET /api/v1/places/{placeId}

- 상세: 주소/영업시간/가격레벨/전화/사진/별점/리뷰수/
설명 = Wikipedia 요약(ko→en 폴백) → Google editorial → generative.description → generative.overview → areaSummary
(상세에서는 addressDescriptor(~인근/일대)는 사용하지 않음)

GET /api/v1/places/{placeId}/reviews?limit={n}

- 작성자/아바타/별점/본문/상대시간

2) Google Places 연동

DTO

PlacesV1SearchTextResponse / PlacesV1PlaceDetailsResponse

- addressDescriptor를 객체(landmarks/areas)로 매핑하여 역직렬화 오류 해결

서비스

- 목록/상세 각각에 맞는 소개 폴백 로직 분리(상세는 문단형만 허용)

3) Wikipedia 연동

WikipediaClient (내부 REST 호출)

- 장소명 기준 요약 시도, 실패 시 위/경도 근접 검색(옵션) → 최종 텍스트 반환

- 위키를 사용했지만 정보 반환이 제대로 안되어 다른 방법으로 시도해야 함


## 🚨 주요 리뷰 포인트


- GeoUtils(거리 계산/표기)

- RestTemplate UA 헤더 및 Accept-Language 적용

## 📸 스크린샷 

### 장소 정보 간략히 조회
<img width="692" height="537" alt="image" src="https://github.com/user-attachments/assets/3f0c1f9c-d9ac-4558-9c32-62405441ec80" />

### 장소 상세히 조회
<img width="705" height="502" alt="image" src="https://github.com/user-attachments/assets/91664128-e90b-46b3-8c41-3dd2e2a01ebd" />

### 해당 장소에 대한 리뷰
<img width="1181" height="373" alt="image" src="https://github.com/user-attachments/assets/9ea7064d-d725-499c-a079-4aec975f190c" />


## 🌱 기타 참고 사항 또는 의견

- google place api에서는 장소 소개와 가격이 null로 반환됨
- open ai api를 사용하여 반환해야 할 거 같음
- 로그인 안된 상태이기에 토큰 없이 구현했고 좋아요에 경우 로그인을 요구해야 할 거 같음
