### PR TITLE
[FEATURE] 장소 리뷰 CRUD 구현 및 권한 분리

### DIFF
--- a/src/main/java/com/dobongzip/dobong/DobongApplication.java
+++ b/src/main/java/com/dobongzip/dobong/DobongApplication.java
@@ -2,7 +2,9 @@ package com.dobongzip.dobong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DobongApplication {
 

--- a/src/main/java/com/dobongzip/dobong/domain/common/BaseEntity.java
+++ b/src/main/java/com/dobongzip/dobong/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.dobongzip.dobong.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dobongzip/dobong/domain/mainpage/controller/MainController.java
+++ b/src/main/java/com/dobongzip/dobong/domain/mainpage/controller/MainController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @Tag(name = "메인페이지", description = "메인페이지 조회 API")
 @RestController
-@RequestMapping("/api/mainpage")
+@RequestMapping("/api/v1/mainpage")
 @RequiredArgsConstructor
 public class MainController {
 

--- a/src/main/java/com/dobongzip/dobong/domain/map/controller/PlaceController.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/controller/PlaceController.java
@@ -1,10 +1,21 @@
 package com.dobongzip.dobong.domain.map.controller;
 
+import com.dobongzip.dobong.domain.map.dto.request.ReviewCreateRequest;
+import com.dobongzip.dobong.domain.map.dto.request.ReviewUpdateRequest;
 import com.dobongzip.dobong.domain.map.dto.response.PlaceDetailsResponse;
 import com.dobongzip.dobong.domain.map.dto.response.PlaceDto;
+import com.dobongzip.dobong.domain.map.dto.response.ReviewIdResponse;
 import com.dobongzip.dobong.domain.map.dto.response.ReviewListResponse;
 import com.dobongzip.dobong.domain.map.service.PlaceService;
+import com.dobongzip.dobong.domain.map.service.ReviewService;
 import com.dobongzip.dobong.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -16,14 +27,20 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "맵 페이지", description ="도봉구 장소정보+리뷰 API")
 @RequestMapping(value = "/api/v1/places", produces = MediaType.APPLICATION_JSON_VALUE)
 @Validated
 public class PlaceController {
 
     private final PlaceService placeService;
+    private final ReviewService reviewService;
 
-    /** ① 검색(목록/카드) — 이름, 별점, 리뷰수, 거리, 전화(있으면), 대표사진 1장 */
-    // 예: GET /api/v1/places/dobong?lat=37.665&lng=127.043&limit=10
+    @Operation(
+            summary = "도봉 명소 검색(목록/카드)",
+            description = """
+                    사용자 좌표 기준으로 도봉구 명소를 검색합니다.
+                    이름, 주소, 거리, 대표사진, 별점/리뷰수, 영업시간, 가격레벨 등이 포함됩니다.
+                    """)
     @GetMapping("/dobong")
     public ResponseEntity<CommonResponse<List<PlaceDto>>> getDobong(
             @RequestParam @DecimalMin("-90.0")  @DecimalMax("90.0")  double lat,
@@ -35,22 +52,83 @@ public class PlaceController {
         return ResponseEntity.ok(CommonResponse.onSuccess(list));
     }
 
-    /** ② 상세 — 장소 소개(에디토리얼/제너러티브), 주소, 이용시간, 이용금액(가격레벨), 사진들, 전화, 별점/리뷰수 */
-    // 예: GET /api/v1/places/{placeId}
+    @Operation(
+            summary = "장소 상세 조회",
+            description = "Wikipedia/Google 소개, 주소, 영업시간, 가격레벨, 전화, 사진들, 별점/리뷰수를 반환합니다."
+    )
     @GetMapping("/{placeId}")
     public ResponseEntity<CommonResponse<PlaceDetailsResponse>> getPlaceDetail(@PathVariable String placeId) {
         var dto = placeService.getPlaceDetail(placeId);
         return ResponseEntity.ok(CommonResponse.onSuccess(dto));
     }
 
-    /** ③ 리뷰 목록 — 평균 별점, 리뷰수, 리뷰 리스트(작성자/별점/본문/상대시간/아바타 등) */
-    // 예: GET /api/v1/places/{placeId}/reviews?limit=20
+    @Operation(
+            summary = "리뷰 목록(로컬+구글 합산)",
+            description = """
+                    로컬(DB) 리뷰와 Google 리뷰를 합쳐 반환합니다.
+                    로컬 리뷰 항목에는 isMine 플래그가 포함되어 로그인 사용자의 리뷰 여부를 구분할 수 있습니다.
+                    비로그인 호출도 가능합니다.
+                    """)
     @GetMapping("/{placeId}/reviews")
-    public ResponseEntity<CommonResponse<ReviewListResponse>> getPlaceReviews(
+    public ResponseEntity<CommonResponse<ReviewListResponse>> getCombinedReviews(
             @PathVariable String placeId,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit
     ) {
-        var dto = placeService.getPlaceReviews(placeId, limit);
+        ReviewService.AvatarResolver avatar = (memberId) -> null; // TODO: 회원 프로필 URL 리졸버
+        var dto = reviewService.getCombinedReviews(placeId, limit, false, avatar);
         return ResponseEntity.ok(CommonResponse.onSuccess(dto));
+    }
+
+    @Operation(
+            summary = "리뷰 작성",
+            description = "해당 장소에 로컬(DB) 리뷰를 1인 1개 정책으로 작성합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = ReviewCreateRequest.class),
+                            examples = @ExampleObject(value = """
+                            { "rating": 4.5, "text": "경치가 정말 좋아요!" }
+                            """))
+            ))
+    @PostMapping("/{placeId}/reviews")
+    public ResponseEntity<CommonResponse<?>> createReview(
+            @PathVariable String placeId,
+            @Valid @RequestBody ReviewCreateRequest req
+    ) {
+        Long id = reviewService.create(placeId, req); // 서비스가 401/권한/중복 처리
+        return ResponseEntity.ok(CommonResponse.onSuccess(new ReviewIdResponse(id)));
+    }
+
+    @Operation(
+            summary = "리뷰 수정",
+            description = "작성자 본인만 리뷰를 수정할 수 있습니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = ReviewUpdateRequest.class),
+                            examples = @ExampleObject(value = """
+                            { "rating": 4.0, "text": "재방문 후 수정: 야간 풍경이 더 좋아요." }
+                            """))))
+    @PutMapping("/{placeId}/reviews/{reviewId}")
+    public ResponseEntity<CommonResponse<?>> updateReview(
+            @PathVariable String placeId,
+            @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewUpdateRequest req
+    ) {
+        reviewService.update(placeId, reviewId, req);
+        return ResponseEntity.ok(CommonResponse.onSuccess("UPDATED"));
+    }
+
+    @Operation(
+            summary = "리뷰 삭제(소프트)",
+            description = "작성자 본인만 리뷰를 삭제할 수 있습니다. 소프트 삭제 처리합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @DeleteMapping("/{placeId}/reviews/{reviewId}")
+    public ResponseEntity<CommonResponse<?>> deleteReview(
+            @PathVariable String placeId,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.delete(placeId, reviewId);
+        return ResponseEntity.ok(CommonResponse.onSuccess("DELETED"));
     }
 }

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,8 @@
+package com.dobongzip.dobong.domain.map.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record ReviewCreateRequest(
+        @NotNull @DecimalMin("0.5") @DecimalMax("5.0") Double rating,
+        @NotBlank @Size(max = 5000) String text
+) {}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/request/ReviewUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.dobongzip.dobong.domain.map.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record ReviewUpdateRequest(
+        @NotNull @DecimalMin("0.5") @DecimalMax("5.0") Double rating,
+        @NotBlank @Size(max = 5000) String text
+) {}

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/ReviewIdResponse.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/ReviewIdResponse.java
@@ -1,0 +1,4 @@
+package com.dobongzip.dobong.domain.map.dto.response;
+
+public record ReviewIdResponse(Long id) {}
+

--- a/src/main/java/com/dobongzip/dobong/domain/map/dto/response/ReviewListResponse.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/dto/response/ReviewListResponse.java
@@ -20,5 +20,6 @@ public class ReviewListResponse {
         private Double rating;             // 별점
         private String text;               // 본문
         private String relativeTime;       // "1시간 전" 등
+        private boolean isMine;
     }
 }

--- a/src/main/java/com/dobongzip/dobong/domain/map/entity/PlaceReview.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/entity/PlaceReview.java
@@ -1,0 +1,51 @@
+package com.dobongzip.dobong.domain.map.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@Table(name = "place_review")
+@Getter @Builder @AllArgsConstructor @NoArgsConstructor
+public class PlaceReview {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String placeId;
+
+    @Column(nullable = false)
+    private Long authorId;
+
+    @Column(nullable = false, length = 100)
+    private String authorName;
+
+    @Column(nullable = false)
+    private Double rating;
+
+    @Column(columnDefinition = "text")
+    private String text;
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    public void edit(Double rating, String text, String editorName) {
+        this.rating = rating;
+        this.text = text;
+        this.authorName = editorName;
+    }
+
+    public void softDelete() { this.deleted = true; }
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/repository/PlaceReviewRepository.java
@@ -1,0 +1,38 @@
+package com.dobongzip.dobong.domain.map.repository;
+
+import com.dobongzip.dobong.domain.map.entity.PlaceReview;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
+
+    @Query("""
+      select r from PlaceReview r
+      where r.placeId = :placeId and r.deleted = false
+      order by r.createdAt desc
+    """)
+    List<PlaceReview> findRecentByPlace(@Param("placeId") String placeId, Pageable pageable);
+
+    @Query("""
+      select avg(r.rating) from PlaceReview r
+      where r.placeId = :placeId and r.deleted = false
+    """)
+    Double avgRating(@Param("placeId") String placeId);
+
+    @Query("""
+      select count(r) from PlaceReview r
+      where r.placeId = :placeId and r.deleted = false
+    """)
+    long countByPlace(@Param("placeId") String placeId);
+
+    Optional<PlaceReview> findByIdAndDeletedFalse(Long id);
+
+    Optional<PlaceReview> findByPlaceIdAndAuthorIdAndDeletedFalse(String placeId, Long authorId);
+
+    boolean existsByPlaceIdAndAuthorIdAndDeletedFalse(String placeId, Long authorId);
+}

--- a/src/main/java/com/dobongzip/dobong/domain/map/service/PlaceService.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/service/PlaceService.java
@@ -6,7 +6,6 @@ import com.dobongzip.dobong.domain.map.dto.response.PlaceDetailsResponse;
 import com.dobongzip.dobong.domain.map.dto.response.PlaceDto;
 import com.dobongzip.dobong.domain.map.dto.response.PlacesV1PlaceDetailsResponse;
 import com.dobongzip.dobong.domain.map.dto.response.PlacesV1SearchTextResponse;
-import com.dobongzip.dobong.domain.map.dto.response.ReviewListResponse;
 import com.dobongzip.dobong.domain.map.util.GeoUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -132,30 +131,6 @@ public class PlaceService {
     }
 
 
-    public ReviewListResponse getPlaceReviews(String placeId, int limit) {
-        var d = v1.fetchPlaceReviews(placeId);
-        if (d == null) return ReviewListResponse.builder()
-                .placeId(placeId).rating(null).reviewCount(0).reviews(List.of()).build();
-
-        var reviews = Optional.ofNullable(d.getReviews())
-                .orElseGet(List::of).stream()
-                .limit(limit)
-                .map(r -> ReviewListResponse.Review.builder()
-                        .authorName(r.getAuthorAttribution() != null ? r.getAuthorAttribution().getDisplayName() : null)
-                        .authorProfilePhoto(r.getAuthorAttribution() != null ? r.getAuthorAttribution().getPhotoUri() : null)
-                        .rating(r.getRating())
-                        .text(r.getText() != null ? r.getText().getText() : null)
-                        .relativeTime(r.getRelativePublishTimeDescription())
-                        .build())
-                .toList();
-
-        return ReviewListResponse.builder()
-                .placeId(d.getId())
-                .rating(d.getRating())
-                .reviewCount(d.getUserRatingCount())
-                .reviews(reviews)
-                .build();
-    }
 
     // ==========================
     // 내부 헬퍼

--- a/src/main/java/com/dobongzip/dobong/domain/map/service/ReviewService.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/service/ReviewService.java
@@ -1,0 +1,246 @@
+package com.dobongzip.dobong.domain.map.service;
+
+import com.dobongzip.dobong.domain.map.client.GooglePlacesClientV1;
+import com.dobongzip.dobong.domain.map.dto.request.ReviewCreateRequest;
+import com.dobongzip.dobong.domain.map.dto.request.ReviewUpdateRequest;
+import com.dobongzip.dobong.domain.map.dto.response.ReviewListResponse;
+import com.dobongzip.dobong.domain.map.entity.PlaceReview;
+import com.dobongzip.dobong.domain.map.repository.PlaceReviewRepository;
+import com.dobongzip.dobong.domain.user.entity.User;
+import com.dobongzip.dobong.global.exception.BusinessException;
+import com.dobongzip.dobong.global.response.StatusCode;
+import com.dobongzip.dobong.global.security.jwt.AuthenticatedProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewService {
+
+    private final GooglePlacesClientV1 v1;                 // 구글 리뷰 조회용
+    private final PlaceReviewRepository reviewRepository;  // 로컬 리뷰 CRUD용
+    private final AuthenticatedProvider authenticatedProvider;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    // ========= 조회 =========
+
+    /** 구글 리뷰만(Read-only) */
+    @Transactional(readOnly = true)
+    public ReviewListResponse getGoogleReviews(String placeId, int limit) {
+        var d = v1.fetchPlaceReviews(placeId);
+        if (d == null) {
+            return ReviewListResponse.builder()
+                    .placeId(placeId).rating(null).reviewCount(0)
+                    .reviews(List.of()).build();
+        }
+
+        var reviews = Optional.ofNullable(d.getReviews())
+                .orElseGet(List::of).stream()
+                .limit(clamp(limit, 1, 50))
+                .map(r -> ReviewListResponse.Review.builder()
+                        .authorName(r.getAuthorAttribution() != null ? r.getAuthorAttribution().getDisplayName() : null)
+                        .authorProfilePhoto(r.getAuthorAttribution() != null ? r.getAuthorAttribution().getPhotoUri() : null)
+                        .rating(r.getRating())
+                        .text(r.getText() != null ? r.getText().getText() : null)
+                        .relativeTime(r.getRelativePublishTimeDescription())
+                        .isMine(false) // 구글 리뷰는 항상 false
+                        .build())
+                .toList();
+
+        return ReviewListResponse.builder()
+                .placeId(d.getId())
+                .rating(d.getRating())
+                .reviewCount(d.getUserRatingCount())
+                .reviews(reviews)
+                .build();
+    }
+
+    /** 로컬(DB) 리뷰만 */
+    @Transactional(readOnly = true)
+    public ReviewListResponse getLocalReviews(String placeId, int limit, AvatarResolver avatar) {
+        Long me = authenticatedProvider.currentUserIdOrNull(); // 익명 가능
+
+        var rows = reviewRepository.findRecentByPlace(placeId, PageRequest.of(0, clamp(limit, 1, 50)));
+
+        var list = rows.stream()
+                .map(r -> ReviewListResponse.Review.builder()
+                        .authorName(r.getAuthorName())
+                        .authorProfilePhoto(avatar != null ? avatar.photoUrlFor(r.getAuthorId()) : null)
+                        .rating(r.getRating())
+                        .text(r.getText())
+                        .relativeTime(toRelative(r.getCreatedAt()))
+                        .isMine(Objects.equals(r.getAuthorId(), me))
+                        .build())
+                .toList();
+
+        Double avg = reviewRepository.avgRating(placeId);
+        long cnt   = reviewRepository.countByPlace(placeId);
+
+        return ReviewListResponse.builder()
+                .placeId(placeId)
+                .rating(avg == null ? null : roundHalf(avg))
+                .reviewCount(Math.toIntExact(cnt))
+                .reviews(list)
+                .build();
+    }
+
+    /** 구글 + 로컬 합산(가중 평균) + 옵션: 내 리뷰 상단 고정 */
+    @Transactional(readOnly = true)
+    public ReviewListResponse getCombinedReviews(String placeId,
+                                                 int limit,
+                                                 boolean pinMineTop,
+                                                 AvatarResolver avatar) {
+
+        // 1) 구글 일부
+        var g = getGoogleReviews(placeId, Math.min(10, limit));
+        long gCnt = Optional.ofNullable(g.getReviewCount()).map(Integer::longValue).orElse(0L);
+        Double gAvg = g.getRating();
+
+        // 2) 로컬
+        var localOnly = getLocalReviews(placeId, limit, avatar);
+        long lCnt = Optional.ofNullable(localOnly.getReviewCount()).map(Integer::longValue).orElse(0L);
+        Double lAvg = localOnly.getRating();
+
+        // 3) 통계 합산
+        Double combinedAvg = null;
+        Integer combinedCnt = null;
+        if ((gCnt + lCnt) > 0) {
+            combinedAvg = ((gAvg == null ? 0.0 : gAvg) * gCnt + (lAvg == null ? 0.0 : lAvg) * lCnt) / (gCnt + lCnt);
+            combinedAvg = roundHalf(combinedAvg);
+            combinedCnt = Math.toIntExact(gCnt + lCnt);
+        }
+
+        // 4) 리스트 합치기(로컬 우선 + 구글 일부)
+        var merged = new ArrayList<ReviewListResponse.Review>(localOnly.getReviews());
+        merged.addAll(g.getReviews());
+
+        // 5) 내 리뷰 상단 고정
+        if (pinMineTop) {
+            var user = authenticatedProvider.isAuthenticated() ? authenticatedProvider.getCurrentUser() : null;
+            if (user != null) {
+                var my = getMyReviewView(placeId,
+                        user.getId(),
+                        avatar != null ? avatar.photoUrlFor(user.getId()) : null,
+                        displayNameOf(user));
+                if (my != null) {
+                    merged.removeIf(r ->
+                            Objects.equals(r.getAuthorName(), my.getAuthorName()) &&
+                                    Objects.equals(r.getText(), my.getText()) &&
+                                    Objects.equals(r.getRating(), my.getRating())
+                    );
+                    merged.add(0, my);
+                }
+            }
+        }
+
+        return ReviewListResponse.builder()
+                .placeId(placeId)
+                .rating(combinedAvg != null ? combinedAvg : localOnly.getRating())
+                .reviewCount(combinedCnt != null ? combinedCnt : localOnly.getReviewCount())
+                .reviews(merged.stream().limit(clamp(limit, 1, 50)).toList())
+                .build();
+    }
+
+    /** 내가 남긴 리뷰 1개(뷰용) */
+    @Transactional(readOnly = true)
+    public ReviewListResponse.Review getMyReviewView(String placeId, Long me, String myPhotoUrl, String myName) {
+        if (me == null) return null;
+        return reviewRepository.findByPlaceIdAndAuthorIdAndDeletedFalse(placeId, me)
+                .map(r -> ReviewListResponse.Review.builder()
+                        .authorName(r.getAuthorName())
+                        .authorProfilePhoto(myPhotoUrl)
+                        .rating(r.getRating())
+                        .text(r.getText())
+                        .relativeTime(toRelative(r.getCreatedAt()))
+                        .isMine(true)
+                        .build())
+                .orElse(null);
+    }
+
+    // ========= CRUD(서비스에서 인증 처리) =========
+
+    public Long create(String placeId, ReviewCreateRequest req) {
+        var user = authenticatedProvider.getCurrentUser(); // 비로그인 시 내부에서 401 던짐
+        Long me = user.getId();
+        String myDisplayName = displayNameOf(user);
+
+        if (reviewRepository.existsByPlaceIdAndAuthorIdAndDeletedFalse(placeId, me)) {
+            throw BusinessException.of(StatusCode.REVIEW_ALREADY_EXISTS);
+        }
+        var saved = reviewRepository.save(PlaceReview.builder()
+                .placeId(placeId)
+                .authorId(me)
+                .authorName(myDisplayName)
+                .rating(req.rating())
+                .text(req.text())
+                .deleted(false)
+                .build());
+        return saved.getId();
+    }
+
+    public void update(String placeId, Long reviewId, ReviewUpdateRequest req) {
+        var user = authenticatedProvider.getCurrentUser(); // 401 처리
+        Long me = user.getId();
+        String myDisplayName = displayNameOf(user);
+
+        var r = reviewRepository.findByIdAndDeletedFalse(reviewId)
+                .orElseThrow(() -> BusinessException.of(StatusCode.REVIEW_NOT_FOUND));
+        if (!Objects.equals(r.getPlaceId(), placeId) || !Objects.equals(r.getAuthorId(), me)) {
+            throw BusinessException.of(StatusCode.REVIEW_FORBIDDEN);
+        }
+        r.edit(req.rating(), req.text(), myDisplayName);
+    }
+
+    public void delete(String placeId, Long reviewId) {
+        var user = authenticatedProvider.getCurrentUser(); // 401 처리
+        Long me = user.getId();
+
+        var r = reviewRepository.findByIdAndDeletedFalse(reviewId)
+                .orElseThrow(() -> BusinessException.of(StatusCode.REVIEW_NOT_FOUND));
+        if (!Objects.equals(r.getPlaceId(), placeId) || !Objects.equals(r.getAuthorId(), me)) {
+            throw BusinessException.of(StatusCode.REVIEW_FORBIDDEN);
+        }
+        r.softDelete();
+    }
+
+    // ========= util =========
+
+    public interface AvatarResolver { String photoUrlFor(Long memberId); }
+
+    private static int clamp(int v, int min, int max) { return Math.max(min, Math.min(v, max)); }
+
+    private static double roundHalf(double v) { return Math.round(v * 2) / 2.0; }
+
+    private static String toRelative(java.time.LocalDateTime createdAt) {
+        if (createdAt == null) return "-"; // ← 안전장치
+        ZonedDateTime now = ZonedDateTime.now(KST);
+        ZonedDateTime then = createdAt.atZone(KST);
+        var d = java.time.Duration.between(then, now);
+        long s = d.getSeconds();
+        if (s < 60) return "방금";
+        long m = s/60; if (m < 60) return m + "분 전";
+        long h = m/60; if (h < 24) return h + "시간 전";
+        long day = h/24; if (day < 7) return day + "일 전";
+        long w = day/7; if (w < 5) return w + "주 전";
+        long mon = day/30; if (mon < 12) return mon + "개월 전";
+        long y = day/365; return y + "년 전";
+    }
+
+
+    /** 표시 이름: 닉네임 > 이름 > 이메일 아이디 */
+    private String displayNameOf(User u) {
+        if (u == null) return "사용자";
+        if (u.getNickname() != null && !u.getNickname().isBlank()) return u.getNickname();
+        if (u.getName() != null && !u.getName().isBlank()) return u.getName();
+        String email = u.getEmail();
+        return (email != null && email.contains("@")) ? email.substring(0, email.indexOf('@')) : "사용자";
+    }
+}

--- a/src/main/java/com/dobongzip/dobong/global/response/StatusCode.java
+++ b/src/main/java/com/dobongzip/dobong/global/response/StatusCode.java
@@ -12,6 +12,12 @@ public enum StatusCode {
     PROFILE_NOT_COMPLETED(HttpStatus.OK, "AUTH2001", "프로필 정보가 아직 입력되지 않았습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4001", "잘못된 요청입니다."),
 
+
+    // Review 관련
+    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REVIEW4001", "이미 이 장소에 작성한 리뷰가 있습니다. 수정 기능을 이용하세요."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404", "리뷰를 찾을 수 없습니다."),
+    REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW403", "리뷰에 대한 권한이 없습니다."),
+    REVIEW_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REVIEW401", "로그인이 필요합니다."),
     // 유저를 이메일로 찾을 수 없을 때
     USER_NOT_FOUND_BY_EMAIL(HttpStatus.BAD_REQUEST, "USER4004", "해당 이메일로 가입된 사용자가 없습니다."),
     // 소셜 로그인 계정은 비밀번호 변경/설정 불가

--- a/src/main/java/com/dobongzip/dobong/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dobongzip/dobong/global/security/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.dobongzip.dobong.global.security.config;
 import com.dobongzip.dobong.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -19,16 +21,27 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/auth/**",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**","/api/v1/mainpage/**","/api/v1/places/**"
+                        // 공개 엔드포인트 (로그인 불필요)
+                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/v1/mainpage/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/places/dobong",
+                                "/api/v1/places/*",           // 상세
+                                "/api/v1/places/*/reviews"    // 리뷰 목록
                         ).permitAll()
+
+                        // 쓰기/수정/삭제는 로그인 필요
+                        .requestMatchers(HttpMethod.POST,   "/api/v1/places/*/reviews").authenticated()
+                        .requestMatchers(HttpMethod.PUT,    "/api/v1/places/*/reviews/*").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/places/*/reviews/*").authenticated()
+
+                        // 그 외는 기본적으로 인증 필요
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }
+

--- a/src/main/java/com/dobongzip/dobong/global/security/jwt/AuthenticatedProvider.java
+++ b/src/main/java/com/dobongzip/dobong/global/security/jwt/AuthenticatedProvider.java
@@ -6,6 +6,7 @@ import com.dobongzip.dobong.global.exception.BusinessException;
 import com.dobongzip.dobong.global.response.StatusCode;
 import com.dobongzip.dobong.global.security.details.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
@@ -15,27 +16,36 @@ public class AuthenticatedProvider {
 
     private final UserRepository userRepository;
 
-    /**
-     * ✅ 현재 로그인한 사용자의 User 엔티티를 반환
-     */
-    public User getCurrentUser() {
-        CustomUserDetails userDetails = (CustomUserDetails)
-                SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        return userRepository.findByEmailAndLoginType(
-                userDetails.getEmail(),
-                userDetails.getLoginType()
-        ).orElseThrow(() -> new BusinessException(StatusCode.USER_NOT_FOUND));
+    public boolean isAuthenticated() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.isAuthenticated()
+                && !(authentication.getPrincipal() instanceof String); // "anonymousUser" 방지
     }
 
+    /** 현재 SecurityContext의 Principal(CustomUserDetails) 또는 null */
+    public CustomUserDetails getPrincipalOrNull() {
+        if (!isAuthenticated()) return null;
+        Object p = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return (p instanceof CustomUserDetails cud) ? cud : null;
+    }
 
-    /**
-     * ✅ 현재 인증된 사용자 여부 확인
-     */
-    public boolean isAuthenticated() {
-        var authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication != null &&
-                authentication.isAuthenticated() &&
-                !(authentication.getPrincipal() instanceof String); // "anonymousUser" 방지
+    /** 현재 Principal 없으면 401 던짐 */
+    public CustomUserDetails getPrincipalOrThrow() {
+        CustomUserDetails p = getPrincipalOrNull();
+        if (p == null) throw BusinessException.of(StatusCode.REVIEW_UNAUTHORIZED);
+        return p;
+    }
+
+    /** 현재 사용자 엔티티(있으면 반환, 없으면 404) */
+    public User getCurrentUser() {
+        CustomUserDetails userDetails = getPrincipalOrThrow();
+        return userRepository.findByEmailAndLoginType(userDetails.getEmail(), userDetails.getLoginType())
+                .orElseThrow(() -> BusinessException.of(StatusCode.USER_NOT_FOUND));
+    }
+
+    /** 현재 사용자 id or null */
+    public Long currentUserIdOrNull() {
+        CustomUserDetails p = getPrincipalOrNull();
+        return (p != null) ? p.getId() : null;
     }
 }


### PR DESCRIPTION
## 📌 PR 개요

장소(Place) 페이지에서 리뷰를 누구나 조회할 수 있고, 로그인 사용자에 한해 리뷰 작성/수정/삭제가 가능하도록 했습니다. 1개 장소당 1개 리뷰 정책을 적용했습니다.

## ✅ 작업한 사항 (체크리스트)

- [x] 기능 구현 완료
- [x] 기존 코드와 충돌 없음
- [x] 문서 업데이트 필요 (필요 시)

## 🚧 변경 사항 상세 설명

### 비로그인도 리뷰 조회 가능

- GET /api/v1/places/{placeId}/reviews는 인증 없이 호출 가능

- 로그인 상태라면 로컬 리뷰 항목에 isMine 플래그로 내 리뷰 표시

### 로그인 사용자만 리뷰 추가/수정/삭제

- POST/PUT/DELETE는 JWT 필수 (Authorization: Bearer <token>)

### 1개 장소당 1개 리뷰

- 동일 장소에 본인 리뷰가 이미 있으면 생성 시 REVIEW_ALREADY_EXISTS 반환


## 🚨 주요 리뷰 포인트

비로그인으로 작성/수정/삭제 시: `401 UNAUTHORIZED`

본인 리뷰가 아닐 때 수정/삭제 시: `403 REVIEW_FORBIDDEN`

존재하지 않는 리뷰: `404 REVIEW_NOT_FOUND`

동일 장소에 중복 작성: `409 REVIEW_ALREADY_EXISTS`


## 📸 스크린샷 

### 비로그인도 리뷰 조회 가능
<img width="860" height="471" alt="image" src="https://github.com/user-attachments/assets/93695243-8376-4b9c-aa31-894feb5c0c45" />


### 로그인 사용자만 리뷰 추가/수정/삭제
<img width="550" height="452" alt="image" src="https://github.com/user-attachments/assets/9e71cdea-81ec-4523-bb0b-15a315615856" />


### 1개 장소당 1개 리뷰로 제한
<img width="941" height="325" alt="image" src="https://github.com/user-attachments/assets/e7447df0-5a19-4ee5-93ff-a45e54d3fa34" />

## 🌱 기타 참고 사항 또는 의견

- 프론트에게 장소 페이지·리뷰 탭은 비로그인도 접근 가능하다고 알리기
