### PR TITLE
[REFACTOR] 엔티티 매핑과 문화유산 이미지 반환 

### DIFF
--- a/src/main/java/com/dobongzip/dobong/domain/map/entity/PlaceReview.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/entity/PlaceReview.java
@@ -1,5 +1,6 @@
 package com.dobongzip.dobong.domain.map.entity;
 
+import com.dobongzip.dobong.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -7,22 +8,40 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
-
 @Entity
-@Table(name = "place_review")
-@Getter @Builder @AllArgsConstructor @NoArgsConstructor
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "place_review",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_place_user", columnNames = {"place_id", "user_id"})
+        },
+        indexes = {
+                @Index(name = "ix_place_review_place", columnList = "place_id, deleted, created_at"),
+                @Index(name = "ix_place_review_user",  columnList = "user_id")
+        }
+)
 public class PlaceReview {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id") // ← DB 컬럼명과 일치시킴
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "place_id", nullable = false, length = 100)
     private String placeId;
 
-    @Column(nullable = false)
-    private Long authorId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            referencedColumnName = "user_id",           // ← 명시해 주면 더 안전
+            foreignKey = @ForeignKey(name = "fk_place_review_user")
+    )
+    private User author;
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "author_name", nullable = false, length = 100)
     private String authorName;
 
     @Column(nullable = false)
@@ -35,11 +54,15 @@ public class PlaceReview {
     private boolean deleted;
 
     @CreationTimestamp
-    @Column(nullable = false, updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // 편의 메서드
+    public Long getAuthorId() { return author != null ? author.getId() : null; }
 
     public void edit(Double rating, String text, String editorName) {
         this.rating = rating;

--- a/src/main/java/com/dobongzip/dobong/domain/map/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/dobongzip/dobong/domain/map/repository/PlaceReviewRepository.java
@@ -32,7 +32,7 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
 
     Optional<PlaceReview> findByIdAndDeletedFalse(Long id);
 
-    Optional<PlaceReview> findByPlaceIdAndAuthorIdAndDeletedFalse(String placeId, Long authorId);
-
-    boolean existsByPlaceIdAndAuthorIdAndDeletedFalse(String placeId, Long authorId);
+    //  author(User)의 id로 탐색할 때는 Author_Id 형태 사용
+    Optional<PlaceReview> findByPlaceIdAndAuthor_IdAndDeletedFalse(String placeId, Long authorId);
+    boolean existsByPlaceIdAndAuthor_IdAndDeletedFalse(String placeId, Long authorId);
 }

--- a/src/main/java/com/dobongzip/dobong/domain/user/entity/User.java
+++ b/src/main/java/com/dobongzip/dobong/domain/user/entity/User.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user")
+@Table(name = "app_user")
 public class User {
 
     @Id

--- a/src/main/java/com/dobongzip/dobong/global/response/StatusCode.java
+++ b/src/main/java/com/dobongzip/dobong/global/response/StatusCode.java
@@ -1,33 +1,41 @@
 package com.dobongzip.dobong.global.response;
 
-
 import org.springframework.http.HttpStatus;
 
 public enum StatusCode {
     SUCCESS(HttpStatus.OK, "SUCCESS200", "SUCCESS"),
 
-    // 로그인, 회원가입
+    // ── 인증/회원 ─────────────────────────────────────────────────────────────
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH4001", "비밀번호는 6~20자이며, 영문 대/소문자 및 특수문자 중 2가지 이상을 포함해야 합니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH404", "존재하지 않는 사용자입니다."),
     PROFILE_NOT_COMPLETED(HttpStatus.OK, "AUTH2001", "프로필 정보가 아직 입력되지 않았습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "AUTH4002", "이미 등록된 사용자입니다."),
+
+    // ── 공통 요청/검증 ────────────────────────────────────────────────────────
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4001", "잘못된 요청입니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "COMMON4002", "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"),
 
-
-    // Review 관련
+    // ── 리뷰 ─────────────────────────────────────────────────────────────────
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REVIEW4001", "이미 이 장소에 작성한 리뷰가 있습니다. 수정 기능을 이용하세요."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404", "리뷰를 찾을 수 없습니다."),
     REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW403", "리뷰에 대한 권한이 없습니다."),
     REVIEW_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REVIEW401", "로그인이 필요합니다."),
-    // 유저를 이메일로 찾을 수 없을 때
+
+    // ── 유저 관리/소셜 ───────────────────────────────────────────────────────
     USER_NOT_FOUND_BY_EMAIL(HttpStatus.BAD_REQUEST, "USER4004", "해당 이메일로 가입된 사용자가 없습니다."),
-    // 소셜 로그인 계정은 비밀번호 변경/설정 불가
     NOT_ALLOWED_FOR_SOCIAL_LOGIN(HttpStatus.FORBIDDEN, "USER4031", "소셜 로그인 계정은 비밀번호를 설정할 수 없습니다."),
     EMAIL_NOT_PROVIDED(HttpStatus.UNAUTHORIZED, "SOCIAL4011", "소셜 로그인 시 이메일 제공에 동의해야 합니다."),
-    //회원정보 관리
-    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4001", "현재 비밀번호가 일치하지 않습니다."),
-    PASSWORD_CONFIRM_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH4002", "새 비밀번호 확인이 일치하지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401", "이메일 또는 비밀번호가 일치하지 않습니다."),
-    USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "AUTH4002", "이미 등록된 사용자입니다."),
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4003", "현재 비밀번호가 일치하지 않습니다."), // ← 코드 중복 방지로 AUTH4003 사용 권장
+    PASSWORD_CONFIRM_NOT_MATCH(HttpStatus.BAD_REQUEST, "AUTH4004", "새 비밀번호 확인이 일치하지 않습니다."), // ← 코드 중복 방지로 AUTH4004
+
+    // ── 외부 API(서울시/도봉구) ──────────────────────────────────────────────
+    SEOUL_EVENT_API_FAILED(HttpStatus.BAD_GATEWAY, "EXT5021", "서울시 문화행사 API 호출에 실패했습니다."),
+    SEOUL_EVENT_API_BAD_RESPONSE(HttpStatus.BAD_GATEWAY, "EXT5022", "서울시 문화행사 API 응답 형식이 올바르지 않습니다."),
+    DOBONG_OPENAPI_FAILED(HttpStatus.BAD_GATEWAY, "EXT5023", "도봉구 오픈API 호출에 실패했습니다."),
+    DOBONG_OPENAPI_BAD_RESPONSE(HttpStatus.BAD_GATEWAY, "EXT5024", "도봉구 오픈API 응답 형식이 올바르지 않습니다."),
+
+    // ── 기타 ────────────────────────────────────────────────────────────────
     FAILURE_TEST(HttpStatus.INTERNAL_SERVER_ERROR, "TEST001", "테스트 실패 응답입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER5001", "서버에서 알 수 없는 에러가 발생했습니다.");
 
@@ -45,5 +53,3 @@ public enum StatusCode {
     public String getCode() { return this.code; }
     public String getDescription() { return this.description; }
 }
-
-


### PR DESCRIPTION
## 📌 PR 개요

User ↔ PlaceReview를 1:N(@OneToMany / @ManyToOne) 로 명시적으로 매핑하고, 도봉구 문화유산 목록에 대해 Google Places API(v1) 를 사용해 대표 이미지 URL(IMAGE_URL) 을 자동으로 주입합니다.

## ✅ 작업한 사항 (체크리스트)

- [x] 기능 구현 완료
- [x] 기존 코드와 충돌 없음

## 🚧 변경 사항 상세 설명

1) 도메인 매핑 정리 (User ↔ PlaceReview)
- User
  - @Table(name = "app_user") 사용 (예약어 충돌 회피)
- PlaceReview
  - @ManyToOne(fetch = LAZY) @JoinColumn(name = "user_id", referencedColumnName = "user_id")
- DB 제약 정리
  - place_review.user_id → app_user.user_id FK 추가: fk_place_review_user
  - 의도치 않은 제약 제거: UNIQUE KEY uk_place_author (place_id) 드롭 

2) 문화유산 이미지 자동 주입 (Google Places API v1)
- 클라이언트: GooglePlacesClientV1
  - 신규 메서드 추가: Optional<String> searchFirstPhotoUrlByText(String textQuery, Double lat, Double lng, int maxWidthPx)
- 메인 서비스 통합: MainService#getDobongCulturalHeritage()
  - 오픈API의 각 항목에 대해 SHD_NM + 주소(+ LAT/LNG)로 검색
  
## 🚨 주요 리뷰 포인트

성능/쿼터

현재 15건이라 영향 미미하나, 확장 시 캐싱 전략 검토


## 📸 스크린샷 

### 문화유산 정보
<img width="627" height="311" alt="image" src="https://github.com/user-attachments/assets/e61da014-fd29-448f-a9ad-0744c0cf97ce" />


## 🌱 기타 참고 사항 또는 의견

google place api 생각보다 유용하다