### PR TITLE
chore: GitHub Actions에서 Gradle 빌드(bootJar) 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # ✅ JDK & Gradle 세팅 + Boot JAR 생성
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle (cache)
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build Boot JAR
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean bootJar -x test
+          ls -al build/libs
+
+      # ✅ Docker 빌드/푸시
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -90,4 +108,3 @@ jobs:
             docker stack deploy -c stack.yml dobong --with-registry-auth
             docker service ls
             docker service ps dobong_api --no-trunc
-      


### PR DESCRIPTION
## 📌 PR 개요

Dockerfile이 COPY build/libs/*.jar app.jar를 수행하는데, GitHub Actions 워크플로우에 Gradle 빌드(bootJar) 단계가 없어 build/libs가 생성되지 않아 실패했습니다.
이를 해결하기 위해 JDK/Gradle 세팅 + bootJar 빌드 스텝을 docker build 이전에 추가했습니다.

## ✅ 작업한 사항 (체크리스트)

- [x] 기능 구현 완료
- [x] 기존 코드와 충돌 없음
- [x] 문서 업데이트 필요 (필요 시)

## 🚧 변경 사항 상세 설명

```
- name: Set up JDK 17
  uses: actions/setup-java@v4
  with:
    distribution: 'temurin'
    java-version: '17'

- name: Set up Gradle (cache)
  uses: gradle/actions/setup-gradle@v3

- name: Build Boot JAR
  run: |
    chmod +x ./gradlew
    ./gradlew clean bootJar -x test
    ls -al build/libs
```


