### PR TITLE
[FIX] build/libs 두 단계를 제거하고 파일만 평탄화(flatten)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         uses: appleboy/ssh-action@v1.2.0
         env:
           SERVER_DIR: ${{ env.SERVER_DIR }}
-          APP_ENV: ${{ secrets.APP_ENV }}   # 멀티라인 .env 전체 내용
+          APP_ENV: ${{ secrets.APP_ENV }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
@@ -63,7 +63,7 @@ jobs:
             sudo chown -R "${USER}:${USER}" "$SERVER_DIR"
             sudo chmod 755 /home/ubuntu /home/ubuntu/BE
 
-            # .env 갱신(있으면 유지, 시크릿이 넘어오면 덮어씀), CRLF 제거
+            # .env 생성 및 CRLF 제거
             if [ -n "${APP_ENV:-}" ]; then
               printf "%s\n" "$APP_ENV" > "$SERVER_DIR/.env.tmp"
               tr -d '\r' < "$SERVER_DIR/.env.tmp" > "$SERVER_DIR/.env"
@@ -79,7 +79,7 @@ jobs:
 
             ls -ld "$SERVER_DIR" "$SERVER_DIR/upload"
 
-      # JAR 업로드 (단일 파일, strip_components 제거)
+      # JAR 업로드 (단일 파일 + strip_components=2 로 경로 평탄화)
       - name: Copy JAR to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -88,8 +88,9 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           source: "${{ steps.pick.outputs.jar }}"
-          target: "${{ env.SERVER_DIR }}/upload"
+          target: "${{ env.SERVER_DIR }}/upload/"
           overwrite: true
+          strip_components: 2   # build/libs 구조 제거 → upload/ 바로 아래에 JAR만 남김
 
       # 업로드 확인
       - name: Verify upload on EC2
@@ -104,6 +105,7 @@ jobs:
           envs: SERVER_DIR
           script: |
             set -euo pipefail
+            echo "[verify] uploaded jars under $SERVER_DIR/upload"
             ls -lt "$SERVER_DIR/upload" | head -n 5
             ls -t "$SERVER_DIR"/upload/*.jar | head -n 1
 


### PR DESCRIPTION
## 📌 PR 개요

scp-action 업로드 시 build/libs 디렉터리 구조가 그대로 보존되어 서버에 upload/build/libs/*.jar로 복사되던 문제를 수정했습니다.
strip_components: 2를 적용해 build/libs 두 단계를 제거하고, JAR가 upload/ 바로 아래로 평탄화(flatten) 되도록 변경했습니다.
또한 타깃 경로에 트레일링 슬래시(/)를 추가해 디렉터리 인식 문제를 방지했습니다.

## ✅ 작업한 사항 (체크리스트)

- [ ] 기능 구현 완료
- [ ] 테스트 코드 작성 완료
- [x] 기존 코드와 충돌 없음
- [ ] 문서 업데이트 필요 (필요 시)

## 🚧 변경 사항 상세 설명

`.github/workflows/deploy.yml
`
`Copy JAR to EC2` 스텝에서 `source`를 `${{ steps.pick.outputs.jar }}`로 고정하고, `target`에 슬래시(/) 추가. strip_components: 2 적용으로 build/libs 폴더 구조 제거. 업로드 검증/재기동 로직은 그대로 동작하도록 유지

## 🚨 주요 리뷰 포인트

- upload/ 바로 아래에 *.jar가 놓이는지 (upload/build/libs/...가 아닌지)

- Pick latest jar에서 선택된 JAR 경로가 scp의 source로 정확히 전달되는지

- 기존 재기동 로직과 충돌 없이 정상 동작하는지 (systemctl is-active --quiet로 실패 시 워크플로 실패 처리되는지)



## 🌱 기타 참고 사항 또는 의견

strip_components 값은 소스 경로가 build/libs/*.jar일 때 항상 2여야 원하는 평탄화가 됩니다.