### PR TITLE
[REFACTOR] 1단계 회원가입에서 active(true)

### DIFF
--- a/src/main/java/com/dobongzip/dobong/global/security/service/AuthService.java
+++ b/src/main/java/com/dobongzip/dobong/global/security/service/AuthService.java
@@ -68,6 +68,7 @@ public class AuthService {
                 .phoneNumber(request.getPhoneNumber())
                 .loginType(LoginType.APP)
                 .profileCompleted(false)
+                .active(true)
                 .build();
 
         userRepository.save(user);
@@ -129,6 +130,7 @@ public class AuthService {
                             .email(claims.email())
                             .loginType(LoginType.KAKAO)
                             .profileCompleted(false)
+                            .active(true)
                             .build();
                     return userRepository.save(newbie);
                 });
@@ -151,6 +153,7 @@ public class AuthService {
                                 .email(claims.email())
                                 .loginType(LoginType.GOOGLE)
                                 .profileCompleted(false) // 닉네임/이름/프사는 2단계에서 입력
+                                .active(true)
                                 .build()
                 ));
 


### PR DESCRIPTION
## 📌 PR 개요

앱 자체 회원가입(1단계) 이후에 2단계 회원정보를 입력하는 부분에서 401 에러가 발생하여 1단계에서 active true를 반환합니다.


## 🌱 기타 참고 사항 또는 의견

active = true (1단계부터 true)

의미: "이 계정은 유효하다. 로그인이 허용된다."

목적: 이 계정으로 발급된 JWT 토큰이 유효하며, JwtAuthenticationFilter를 통과할 자격이 있음을 의미합니다.

에러 발생 이유: 유저의 user.isActive()가 false여서 401이 발생